### PR TITLE
beta 250927

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# **Ads Media Planner**
+# Ads Media Planner
 
 Complete WordPress Advertising Management Solution. **Ads Media Planner** is a powerful WordPress plugin that provides comprehensive advertising management directly within your WordPress dashboard. Perfect for publishers and content creators looking to optimize ad revenue while maintaining site performance.
 
@@ -8,8 +8,6 @@ Complete WordPress Advertising Management Solution. **Ads Media Planner** is a p
 - **Complete Inventory Control:** Create, manage, and organize your entire ad unit inventory from a centralized dashboard
 - **Flexible Placement Options:** Deploy ads through global site settings or precise block-based placement for maximum revenue optimization
 - **Content-Sensitive Controls:** Fine-tune ad frequency and positioning within articles to balance revenue with user experience
-- **Performance Optimization:** Control lazy loading and active-view refresh to maintain page speed while maximizing viewability
-- **Content Relevance Tools:** Suppress ads on specific categories or tags to ensure brand safety and contextual relevance
 
 ## Why Choose **Ads Media Planner**?
 
@@ -36,3 +34,8 @@ use slug of the block or place name
 ```
 [ads_media_planner place="sidebar_shortcode"]
 ```
+
+# Roadmap
+- **Performance Optimization:** Control lazy loading and active-view refresh to maintain page speed while maximizing viewability
+- **Content Relevance Tools:** Suppress ads on specific categories or tags to ensure brand safety and contextual relevance
+- **Advanced Analytics Integration:** Connect with Google Analytics and other platforms to track ad performance and user engagement

--- a/includes/Places.php
+++ b/includes/Places.php
@@ -2,25 +2,32 @@
 
 namespace AdsMediaPlanner;
 
-Places::init();
+/**
+ * todo - rename file to Placements.php
+ */
+Placements::init();
 
-class Places
+class Placements
 {
     public static $places = [];
 
     public static function init()
     {
+        add_shortcode('ads_media_planner', [self::class, 'renderShortcode']);
+
         add_action('init', [self::class, 'addPlaces']);
         add_action('add_meta_boxes', [self::class, 'addMetaBox']);
         add_action('save_post', [self::class, 'saveMetaBox']);
         add_action('manage_posts_custom_column', [self::class, 'addAdminListColumnContent'], 10, 2);
         add_filter('manage_edit-ad-block_columns', [self::class, 'addAdminListColumn']);
 
-        add_shortcode('ads_media_planner', [self::class, 'renderShortcode']);
-
         add_action('init', function () {
 
             if (Settings::isEnabled()) {
+                if (self::isDisabledForLoggedInUsers() && is_user_logged_in()) {
+                    return;
+                }
+
                 add_action('wp_footer', [self::class, 'render_fullscreen_in_footer']);
                 add_action('wp_body_open', [self::class, 'render_fullscreen_in_body']);
 
@@ -31,7 +38,20 @@ class Places
 
     }
 
-    public static function renderShortcode($atts) {
+    //is disable for logged in users
+    public static function isDisabledForLoggedInUsers()
+    {
+        return Settings::get('disable_for_logged_in') ?? false;
+    }
+
+    public static function renderShortcode($atts)
+    {
+
+        //if disable for logged in users
+        if (self::isDisabledForLoggedInUsers() && is_user_logged_in()) {
+            return '';
+        }
+
         $block = $atts['block'] ?? '';
         if (! empty($block)) {
             $ads = get_post($block);
@@ -43,7 +63,7 @@ class Places
         }
 
         $place = $atts['place'] ?? '';
-        if($place){
+        if ($place) {
             return self::getBlocksForPlace($place);
         }
 
@@ -66,33 +86,41 @@ class Places
     public static function renderAfterContent($content)
     {
         $advertising_content = self::getBlocksForPlace('after_content');
-        if(empty(trim($advertising_content))) {
+        if (empty(trim($advertising_content))) {
             return $content;
         }
         $advertising_content = sprintf('<div class="ad-media-planner ad-after-content">%s</div>', $advertising_content);
 
-        return $content . $advertising_content;
+        return $content.$advertising_content;
     }
 
     public static function renderBeforeContent($content)
     {
         $advertising_content = self::getBlocksForPlace('before_content');
-        if(empty(trim($advertising_content))) {
+        if (empty(trim($advertising_content))) {
             return $content;
         }
         $advertising_content = sprintf('<div class="ad-media-planner ad-before-content">%s</div>', $advertising_content);
 
-        return $advertising_content . $content;
+        return $advertising_content.$content;
     }
 
     public static function render_fullscreen_in_body()
     {
-        return self::getBlocksForPlace('fullscreen-in-body');
+        $content = self::getBlocksForPlace('fullscreen-in-body');
+        $content = trim($content);
+        if ($content) {
+            echo $content;
+        }
     }
 
     public static function render_fullscreen_in_footer()
     {
-        return self::getBlocksForPlace('fullscreen-in-footer');
+        $content = self::getBlocksForPlace('fullscreen-in-footer');
+        $content = trim($content);
+        if ($content) {
+            printf('<div class="ad-media-planner ad-fullscreen-in-footer">%s</div>', $content);
+        }
     }
 
     public static function addAdminListColumnContent($column, $post_id)

--- a/includes/Places.php
+++ b/includes/Places.php
@@ -123,7 +123,7 @@ class Placements
         $content = self::getBlocksForPlace('fullscreen-in-body');
         $content = trim($content);
         if ($content) {
-            echo $content;
+            printf('<div class="ad-media-planner ad-fullscreen-in-body">%s</div>', $content);
         }
     }
 

--- a/includes/Places.php
+++ b/includes/Places.php
@@ -24,7 +24,7 @@ class Placements
         add_action('init', function () {
 
             if (Settings::isEnabled()) {
-                if (self::isDisabledForLoggedInUsers() && is_user_logged_in()) {
+                if (!self::canShowAds()) {
                     return;
                 }
 

--- a/includes/Places.php
+++ b/includes/Places.php
@@ -44,6 +44,17 @@ class Placements
         return Settings::get('disable_for_logged_in') ?? false;
     }
 
+    //can show Ads? if can show Ads - return true
+    public static function canShowAds()
+    {
+        if (self::isDisabledForLoggedInUsers() && is_user_logged_in()) {
+            return false;
+        }
+
+        return Settings::isEnabled();
+    }
+
+
     public static function renderShortcode($atts)
     {
 
@@ -52,11 +63,12 @@ class Placements
             return '';
         }
 
+        $wrapper = '<div class="ad-media-planner ad-shortcode">%s</div>';
         $block = $atts['block'] ?? '';
         if (! empty($block)) {
             $ads = get_post($block);
             if ($ads) {
-                return $ads->post_content;
+                return sprintf($wrapper, $ads->post_content);
             } else {
                 return '';
             }
@@ -64,7 +76,7 @@ class Placements
 
         $place = $atts['place'] ?? '';
         if ($place) {
-            return self::getBlocksForPlace($place);
+            return sprintf($wrapper, self::getBlocksForPlace($place));
         }
 
         return '';
@@ -78,6 +90,7 @@ class Placements
             'fullscreen-in-body' => 'Fullscreen in Body',
             'before_content' => 'Before Content',
             'after_content' => 'After Content',
+            'shortcode' => 'Shortcode',
         ];
 
         self::$places = apply_filters('ads_media_planner_places', self::$places);

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -77,6 +77,26 @@ class Settings
             self::$page_settings,
             self::$section_general
         );
+
+        //отключить рекламу для авторизованных посетителей
+        add_settings_field(
+            'disable_for_logged_in',
+            'Disable for logged-in users',
+            function ($args) {
+
+                $value = self::get('disable_for_logged_in');
+                printf(
+                    '<input type="checkbox" name="%s" value="1" %s>',
+                    esc_attr(self::getFieldName('disable_for_logged_in')),
+                    checked($value, 1, false)
+                );
+                ?>
+
+            <?php
+            },
+            self::$page_settings,
+            self::$section_general
+        );
     }
 
     public static function add_options_page()

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -78,7 +78,7 @@ class Settings
             self::$section_general
         );
 
-        //отключить рекламу для авторизованных посетителей
+        // disable ads for logged-in users
         add_settings_field(
             'disable_for_logged_in',
             'Disable for logged-in users',

--- a/plugin.php
+++ b/plugin.php
@@ -22,5 +22,15 @@ class Plugin {
         foreach (glob(__DIR__ . "/includes/*.php") as $filename) {
             include_once $filename;
         }
+
+        add_filter('plugin_action_links_' . plugin_basename(__FILE__), [self::class, 'add_settings_link']);
+    }
+
+    // Add settings link to plugins page
+    public static function add_settings_link($links) {
+        $link = admin_url('edit.php?post_type=ad-block&page=ads-media-planner-settings');
+        $settings_link = sprintf('<a href="%s">Settings</a>', esc_url($link));
+        array_unshift($links, $settings_link);
+        return $links;
     }
 }

--- a/plugin.php
+++ b/plugin.php
@@ -8,7 +8,7 @@
  * License: GPL2
  * Domain Path: /languages
  * Text Domain: ads-media-planner
- * Version: 0.1.250928
+ * Version: 0.2.250928
  */
 
 namespace AdsMediaPlanner;


### PR DESCRIPTION
This pull request introduces several significant improvements and refactoring to the ads media planner plugin. The main focus is on renaming and refactoring the `Places` class to `Placements`, adding new settings to control ad visibility for logged-in users, and improving the rendering logic for ad placements. Additionally, a settings link is added to the plugins page for easier access.

**Class and File Refactoring:**
- Renamed the `Places` class to `Placements` and updated all references accordingly. A TODO comment was added to rename the file to `Placements.php` for consistency.

**Ad Visibility Controls:**
- Added a new setting (`disable_for_logged_in`) to allow disabling ads for logged-in users, including a corresponding checkbox in the settings UI.
- Implemented logic in `Placements` to respect this setting, preventing ad rendering for logged-in users where appropriate.

**Rendering Improvements:**
- Improved rendering of ads in the footer and body by wrapping output in containers and only printing content if present.
- Ensured that ads rendered via shortcode are also wrapped in a container for consistent styling.

**Plugin Usability:**
- Added a "Settings" link directly to the plugin’s entry on the WordPress plugins page for easier navigation to configuration.

**Other Updates:**
- Added a new ad placement option labeled "Shortcode" to the available places.
- Updated the plugin version to `0.2.250928`.